### PR TITLE
Add login and blacklist

### DIFF
--- a/src/features/gameboard/types.ts
+++ b/src/features/gameboard/types.ts
@@ -15,6 +15,11 @@ export enum EGrip {
   none,
 }
 
+export type Credentials = {
+  login: string
+  api_key: string
+}
+
 export type PornList = string[]
 
 export type GameEvent<Args extends any[] = []> = (

--- a/src/features/settings/SettingsControls/PornSetting/PornSetting.css
+++ b/src/features/settings/SettingsControls/PornSetting/PornSetting.css
@@ -8,3 +8,8 @@
 .PornSetting__error {
   color: #cc0000;
 }
+
+.PornSetting__textarea {
+  width: 100%;
+  min-height: 6.25em;
+}

--- a/src/features/settings/SettingsControls/PornSetting/PornSetting.css
+++ b/src/features/settings/SettingsControls/PornSetting/PornSetting.css
@@ -4,3 +4,7 @@
   width: 100%;
   margin-top: 10px;
 }
+
+.PornSetting__error {
+  color: #cc0000;
+}

--- a/src/features/settings/SettingsControls/SaveSetting/SaveSetting.tsx
+++ b/src/features/settings/SettingsControls/SaveSetting/SaveSetting.tsx
@@ -38,7 +38,7 @@ export function SaveSetting(props: ISaveSettingProps) {
         <strong>Share these codes around to let others try your settings.</strong>
         <div className="settings-innerrow">
           <em>Either copy and paste a code below and click "load", or set everything else up and hit "save" to update the code shown.</em>
-          <button onClick={() => setCurrentSave(makeSave(props.settings))}>Save</button>
+          <button onClick={() => setCurrentSave(makeSave(props.settings, /*includeCredentials*/ false))}>Save</button>
           <button onClick={() => props.setSettings(prepSave(currentSave, setError))}>Load</button>
         </div>
         <div className="settings-innerrow">

--- a/src/features/settings/SettingsControls/SettingsControls.tsx
+++ b/src/features/settings/SettingsControls/SettingsControls.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react'
 import './SettingsControls.css'
 import { connect } from 'react-redux'
 import { IState } from '../../../store'
-import { PornList } from '../../gameboard/types'
+import { Credentials, PornList } from '../../gameboard/types'
 import { PropsForConnectedComponent } from '../types'
 import { PaceSetting } from './PaceSetting/PaceSetting'
 import { PornSetting } from './PornSetting/PornSetting'
@@ -22,6 +22,7 @@ import { PlayerSetting } from './PlayerSetting/PlayerSetting'
 interface ISettingsControlsProps extends PropsForConnectedComponent {
   pace: IState['settings']['pace']
   steepness: IState['settings']['steepness']
+  credentials: Credentials
   pornList: PornList
   eventList: IState['settings']['eventList']
   duration: IState['settings']['duration']
@@ -37,6 +38,7 @@ export const SettingsControls = connect(
     ({
       pace: state.settings.pace,
       steepness: state.settings.steepness,
+      credentials: state.settings.credentials,
       pornList: state.settings.pornList,
       eventList: state.settings.eventList,
       duration: state.settings.duration,
@@ -49,7 +51,7 @@ export const SettingsControls = connect(
 )(function (props: ISettingsControlsProps) {
   const saveToLocalStorage = useRef(
     debounce((props: ISettingsControlsProps) => {
-      localStorage.setItem('lastSession', makeSave(props))
+      localStorage.setItem('lastSession', makeSave(props, /*includeCredentials*/ true))
     }, 1000),
   )
   useEffect(() => saveToLocalStorage.current(props))
@@ -72,7 +74,11 @@ export const SettingsControls = connect(
 
       <EventsSetting eventList={props.eventList} setEventList={(newList) => props.dispatch(SettingsActions.SetEventList(newList))} />
 
-      <PornSetting pornList={props.pornList} setPornList={(newList) => props.dispatch(SettingsActions.SetPornList(newList))} />
+      <PornSetting
+        credentials={props.credentials}
+        setCredentials={(newCredentials) => props.dispatch(SettingsActions.SetCredentials(newCredentials))}
+        pornList={props.pornList}
+        setPornList={(newList) => props.dispatch(SettingsActions.SetPornList(newList))} />
 
       <WalltakerSetting
         enabled={Boolean(props.walltakerLink ?? false)}

--- a/src/features/settings/store/actions.ts
+++ b/src/features/settings/store/actions.ts
@@ -1,4 +1,4 @@
-import { PornList, EventToken, HypnoMode, PlayerParts, PlayerGender } from '../../gameboard/types'
+import { PornList, EventToken, HypnoMode, PlayerParts, PlayerGender, Credentials } from '../../gameboard/types'
 
 export const T_OPEN_DIALOG = 'OPEN_DIALOG'
 export const T_CLOSE_DIALOG = 'CLOSE_DIALOG'
@@ -6,6 +6,7 @@ export const T_SET_MIN_PACE = 'SET_MIN_PACE'
 export const T_SET_MAX_PACE = 'SET_MAX_PACE'
 export const T_SET_STEEPNESS = 'SET_STEEPNESS'
 export const T_SET_DURATION = 'SET_DURATION'
+export const T_SET_CREDENTIALS = 'SET_CREDENTIALS'
 export const T_SET_PORN_LIST = 'SET_PORN_LIST'
 export const T_SET_EVENT_LIST = 'SET_EVENT_LIST'
 export const T_SET_HYPNO_MODE = 'SET_HYPNO_MODE'
@@ -42,6 +43,11 @@ class SettingsActionsBase {
   SetGameDuration = (duration: number) => ({
     type: T_SET_DURATION as typeof T_SET_DURATION,
     payload: duration,
+  })
+
+  SetCredentials = (credentials: Credentials | null) => ({
+    type: T_SET_CREDENTIALS as typeof T_SET_CREDENTIALS,
+    payload: credentials,
   })
 
   SetPornList = (pornList: PornList) => ({

--- a/src/features/settings/store/reducer.ts
+++ b/src/features/settings/store/reducer.ts
@@ -4,6 +4,7 @@ import {
   T_SET_MAX_PACE,
   T_OPEN_DIALOG,
   T_CLOSE_DIALOG,
+  T_SET_CREDENTIALS,
   T_SET_PORN_LIST,
   T_SET_DURATION,
   T_SET_EVENT_LIST,
@@ -15,7 +16,7 @@ import {
   T_SET_PLAYER_GENDER,
   T_SET_PLAYER_PARTS,
 } from './actions'
-import { PornList, EventToken, HypnoMode, PlayerParts, PlayerGender } from '../../gameboard/types'
+import { PornList, EventToken, HypnoMode, PlayerParts, PlayerGender, Credentials } from '../../gameboard/types'
 import { events } from '../../gameboard/events/index'
 
 export interface ISettingsState {
@@ -26,6 +27,7 @@ export interface ISettingsState {
   }
   steepness: number
   duration: number
+  credentials: Credentials | null
   pornList: PornList
   eventList: EventToken['id'][]
   hypnoMode: HypnoMode
@@ -48,6 +50,7 @@ export const SettingsDefaultState: ISettingsState = {
   },
   steepness: 0.05,
   duration: 6000,
+  credentials: null,
   pornList: [],
   eventList: events.map(event => event.id),
   hypnoMode: HypnoMode.JOI,
@@ -96,6 +99,11 @@ export function SettingsReducer(state: ISettingsState = SettingsDefaultState, ac
       return {
         ...state,
         duration: action.payload,
+      }
+    case T_SET_CREDENTIALS:
+      return {
+        ...state,
+        credentials: action.payload,
       }
     case T_SET_PORN_LIST:
       return {

--- a/src/features/settings/types.ts
+++ b/src/features/settings/types.ts
@@ -13,7 +13,7 @@ export type E621File = {
   url: string | null
 }
 
-export type E621Posts = {
+export type E621Post = {
   id: number
   created_at: string
   updated_at: string
@@ -34,7 +34,7 @@ export type E621Posts = {
   locked_tags: string[]
   change_seq: number
   flags: { pending: boolean; flagged: boolean; note_locked: boolean; status_locked: boolean; rating_locked: boolean; deleted: boolean }
-  rating: 's' | 'e'
+  rating: 's' | 'q' | 'e'
   fav_count: number
   sources: string[]
   pools: number[]
@@ -44,7 +44,7 @@ export type E621Posts = {
   description: string
   comment_count: number
   is_favorited: boolean
-}[]
+}
 
 export type E621User = {
   api_burst_limit: number

--- a/src/features/settings/types.ts
+++ b/src/features/settings/types.ts
@@ -45,3 +45,72 @@ export type E621Posts = {
   comment_count: number
   is_favorited: boolean
 }[]
+
+export type E621User = {
+  api_burst_limit: number
+  api_regen_multiplier: number
+  artist_version_count: number
+  avatar_id: number
+  base_upload_limit: number
+  blacklist_avatars: boolean
+  blacklist_users: boolean
+  blacklisted_tags: string
+  can_approve_posts: boolean
+  can_upload_free: boolean
+  comment_count: number
+  comment_threshold: number
+  created_at: string
+  custom_style: string
+  default_image_size: string
+  description_collapsed_initially: boolean
+  disable_cropped_thumbnails: boolean
+  disable_mobile_gestures: boolean
+  disable_post_tooltips: boolean
+  disable_responsive_mode: boolean
+  disable_user_dmails: boolean
+  email: string
+  enable_auto_complete: boolean
+  enable_compact_uploader: boolean
+  enable_keyboard_navigation: boolean
+  enable_privacy_mode: boolean
+  enable_safe_mode: boolean
+  favorite_count: number
+  favorite_limit: number
+  favorite_tags: string
+  flag_count: number
+  forum_post_count: number
+  has_mail: boolean
+  has_saved_searches: boolean
+  hide_comments: boolean
+  id: number
+  is_banned: boolean
+  last_forum_read_at: string
+  last_logged_in_at: string
+  level: number
+  level_string: string
+  name: string
+  negative_feedback_count: number
+  neutral_feedback_count: number
+  no_feedback: boolean
+  no_flagging: boolean
+  note_update_count: number
+  per_page: number
+  pool_version_count: number
+  positive_feedback_count: number
+  post_update_count: number
+  post_upload_count: number
+  receive_email_notifications: boolean
+  recent_tags: string
+  remaining_api_limit: number
+  replacements_beta: boolean
+  show_avatars: boolean
+  show_hidden_comments: boolean
+  show_post_statistics: boolean
+  statement_timeout: number
+  style_usernames: boolean
+  tag_query_limit: number
+  time_zone: string
+  updated_at: string
+  upload_limit: number
+  wiki_page_version_count: number
+}

--- a/src/helpers/blacklist.ts
+++ b/src/helpers/blacklist.ts
@@ -1,0 +1,161 @@
+// Blacklist logic taken from e621's source, refactored, added types, and added comments
+// https://github.com/zwagoth/e621ng/blob/b4672dadeef12e7aa20401b6074bc7676bb23bbb/app/javascript/src/javascripts/blacklists.js
+
+import { E621Post } from '../features/settings/types'
+
+type InvalidCompairsons = '<<' | '<>' | '><' | '>>'
+type FixableCompairsons = '' | '=' | '=<' | '=>'
+type ValidComparisons = '<' | '<=' | '==' | '>=' | '>'
+type AllComparisons = InvalidCompairsons | FixableCompairsons | ValidComparisons
+type ScoreComparison = {
+  comparison: ValidComparisons | InvalidCompairsons
+  score: number
+}
+
+interface BlacklistEntry {
+  tags: string
+  require: string[]
+  exclude: string[]
+  optional: string[]
+  scoreComparison: ScoreComparison | null
+}
+
+// Fix the comparisions that makes sense
+function fixComparisonInsanity(input: AllComparisons): ValidComparisons | InvalidCompairsons {
+  switch (input) {
+    case '=>':
+      return '>='
+    case '=<':
+      return '<='
+    case '':
+    case '=':
+      return '=='
+    default:
+      return input
+  }
+}
+
+// Does a comparison based on
+// Returns "true" on invalid comparisions
+function rangeComparator(comparison: ScoreComparison, target: number): boolean {
+  switch (comparison.comparison) {
+    case '<':
+      return target < comparison.score
+    case '<=':
+      return target <= comparison.score
+    case '==':
+      return target === comparison.score
+    case '>=':
+      return target >= comparison.score
+    case '>':
+      return target > comparison.score
+    default:
+      return true
+  }
+}
+
+function is_subset(array: any[], subarray: any[]) {
+  return subarray.every(value => array.includes(value))
+}
+
+function intersect(a: any[], b: any[]) {
+  return a.filter(value => b.includes(value))
+}
+
+export class Blacklist {
+  private entries: BlacklistEntry[]
+
+  constructor(blacklistTagsList: string) {
+    this.entries = blacklistTagsList
+      .split('\n')
+      .filter(t => t.trim() !== '')
+      .map(t => Blacklist.entryParse(t))
+  }
+
+  private static entryParse(blacklistTagsString: string): BlacklistEntry {
+    // Convert to lowercase
+    blacklistTagsString = blacklistTagsString.toLowerCase()
+
+    // Remove the afe, uestionable, and xplict
+    blacklistTagsString = blacklistTagsString.replace(/(rating:[sqe])\w+/gi, '$1')
+
+    const entry: BlacklistEntry = {
+      tags: blacklistTagsString,
+      require: [],
+      exclude: [],
+      optional: [],
+      scoreComparison: null,
+    }
+
+    // Split the string on whitespace
+    const matches = blacklistTagsString.match(/\S+/g) || []
+
+    // Loop through each tag and catgorize it
+    for (const tag of matches) {
+      if (tag.charAt(0) === '-') {
+        // If it's a prefix of -, it's excluded
+        entry.exclude.push(tag.slice(1))
+      } else if (tag.charAt(0) === '~') {
+        // If it's a prefix of ~, it's optional
+        entry.optional.push(tag.slice(1))
+      } else if (tag.match(/^score:[<=>]{0,2}-?\d+/)) {
+        // If it's a score, parse the score
+        const score = tag.match(/^score:([<=>]{0,2})(-?\d+)/)!
+        entry.scoreComparison = {
+          comparison: fixComparisonInsanity(score[1] as AllComparisons),
+          score: parseInt(score[2], 10),
+        }
+      } else {
+        // Otherwise it's just required
+        entry.require.push(tag)
+      }
+    }
+    return entry
+  }
+
+  // Using arrow syntax to keep this function bound to this
+  // Pass this function into a post[].filter()
+  public shouldKeepPost = (post: E621Post) => {
+    // Return true unless some blacklist entry matches
+    return !this.entries.some((entry: BlacklistEntry) => {
+      const tags = post.tags.general.concat(
+        post.tags.species,
+        post.tags.character,
+        post.tags.copyright,
+        post.tags.artist,
+        post.tags.invalid,
+        post.tags.lore,
+        post.tags.meta,
+      )
+      tags.push(`id:${post.id}`)
+      tags.push(`rating:${post.rating}`)
+      tags.push(`userid:${post.uploader_id}`)
+      // Unfortunately the post does not return the user's screenname
+      // So user:screenname will not work...
+      // tags.push(`user:${post.user}`)
+      tags.push(`height:${post.file.height}`)
+      tags.push(`width:${post.file.width}`)
+      if (post.is_favorited) tags.push('fav:me')
+      if (post.flags.pending) tags.push('status:pending')
+      if (post.flags.flagged) tags.push('status:flagged')
+      if (post.flags.note_locked) tags.push('status:note_locked')
+      if (post.flags.status_locked) tags.push('status:status_locked')
+      if (post.flags.rating_locked) tags.push('status:rating_locked')
+      if (post.flags.deleted) tags.push('status:deleted')
+
+      if (intersect(tags, entry.exclude).length > 0) {
+        return false
+      }
+
+      if (entry.optional.length > 0 && intersect(tags, entry.optional).length === 0) {
+        return false
+      }
+
+      if (entry.scoreComparison != null && !rangeComparator(entry.scoreComparison, post.score.total)) {
+        return false
+      }
+
+      return is_subset(tags, entry.require)
+    })
+  }
+}


### PR DESCRIPTION
Hello! I would like to add two features to the e621 getter, login and blacklist:
<img width="382" alt="image" src="https://user-images.githubusercontent.com/2957895/184520896-421924ee-ae10-41d6-8167-c46be6baa30c.png">
Login will allow the user to use the votedup:me tag (and voted/voteddown...), as well as being able to use private sets and load the user's blacklist.

When you check the login, it will prompt for credentials:
<img width="375" alt="image" src="https://user-images.githubusercontent.com/2957895/184520945-a27044a5-bc35-4479-88ae-68e832ae0339.png">

After filling it out and clicking "Save credentials" it authenticates and persists your login information (will save to localStorage, but will not be exported in the save/load control
<img width="371" alt="image" src="https://user-images.githubusercontent.com/2957895/184520981-14a3a91a-73a5-479c-b40e-bb0c7560c8b0.png">

If your information is wrong, it will show an error string that will go away after editing either field:
<img width="375" alt="image" src="https://user-images.githubusercontent.com/2957895/184520954-fbfeea27-fcbc-467f-ae36-837b29358871.png">

When you put in this information, it will automatically fetch and fill out the blacklist:
<img width="383" alt="image" src="https://user-images.githubusercontent.com/2957895/182545017-64feb576-bf39-41c5-a0a1-e6ecf2891596.png">

You can modify the blacklist (or turn it off altogether). If you didn't login, you can still manually use the blacklist. It defaults to an empty textbox (which won't filter anything)
<img width="387" alt="image" src="https://user-images.githubusercontent.com/2957895/182545258-90c0afd4-cd8c-46d6-a5ea-fab4c62f7bc3.png">

So what do you think? I tried to stay consistent with the rest of the style of the code, but it's my first time working in React, so let me know if anything is off. Thanks!

Edit: slightly changed the wording, and this time made sure my code was run through the linter. Thanks!